### PR TITLE
pkg/fms: Add page for managing fields

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -5,9 +5,10 @@ before:
   hooks:
     - go mod tidy
     - go generate -tags docs {{ .Env.GENERATE_EXTRA_ARGS }} ./...
-    - wget -N https://use.fontawesome.com/releases/v6.6.0/fontawesome-free-6.6.0-web.zip
+    - wget -Nq https://use.fontawesome.com/releases/v6.6.0/fontawesome-free-6.6.0-web.zip
     - mkdir -p pkg/http/ui/static/fa/
     - bsdtar -xvf fontawesome-free-6.6.0-web.zip --strip-components=1 -C pkg/fms/ui/static/fa/
+    - wget -Nq https://unpkg.com/mustache@4.2.0 -O pkg/fms/ui/static/js/mustache.js
 builds:
   - env:
       - CGO_ENABLED=0

--- a/internal/cmdlets/fms_setup_flash_device.go
+++ b/internal/cmdlets/fms_setup_flash_device.go
@@ -136,7 +136,7 @@ func fieldHardwareFlashDeviceCmdRun(c *cobra.Command, args []string) {
 		return
 	}
 
-	if err := installer.Install(); err != nil {
+	if err := installer.Install(); err != nil && !strings.HasPrefix(err.Error(), "signal") {
 		appLogger.Error("Fatal error during install", "error", err)
 		return
 	}

--- a/pkg/config/fms.go
+++ b/pkg/config/fms.go
@@ -116,7 +116,7 @@ func (c *FMSConfig) SortedTeams() []*Team {
 func (c *FMSConfig) populateRequiredElements() bool {
 	needSave := (c.FMSMac == "") || (c.AutoUser == "") || (c.ViewUser == "") ||
 		(c.AdminPass == "") || (c.AutoPass == "") || (c.ViewPass == "") ||
-		(c.InfrastructureSSID == "")
+		(c.InfrastructureSSID == "") || (c.RadioMode == "")
 
 	xkcd := xkcdpwgen.NewGenerator()
 	xkcd.SetNumWords(3)
@@ -155,6 +155,10 @@ func (c *FMSConfig) populateRequiredElements() bool {
 	if c.InfrastructureSSID == "" {
 		c.InfrastructureSSID = "gizmo"
 		c.InfrastructurePSK = xkcd.GeneratePasswordString()
+	}
+
+	if c.RadioMode == "" {
+		c.RadioMode = "FIELD"
 	}
 
 	return needSave

--- a/pkg/fms/.gitignore
+++ b/pkg/fms/.gitignore
@@ -1,1 +1,2 @@
 ui/static/fa
+ui/static/js/mustache.js

--- a/pkg/fms/fms.go
+++ b/pkg/fms/fms.go
@@ -87,6 +87,7 @@ func New(opts ...Option) (*FMS, error) {
 	})
 
 	r.Route("/api", func(r chi.Router) {
+		r.Get("/config", x.apiGetConfig)
 		r.Get("/eventstream", x.es.Handler)
 		r.Route("/field", func(r chi.Router) {
 			r.Get("/configured-quads", x.configuredQuads)
@@ -106,6 +107,12 @@ func New(opts ...Option) (*FMS, error) {
 			r.Post("/update-wifi", x.apiUpdateNetWifi)
 			r.Post("/update-advanced-net", x.apiUpdateAdvancedNet)
 			r.Post("/update-integrations", x.apiUpdateIntegrations)
+
+			r.Route("/field", func(r chi.Router) {
+				r.Post("/", x.apiFieldAdd)
+				r.Put("/{id}", x.apiFieldUpdate)
+				r.Delete("/{id}", x.apiFieldDelete)
+			})
 		})
 	})
 
@@ -123,6 +130,7 @@ func New(opts ...Option) (*FMS, error) {
 			r.Route("/setup", func(r chi.Router) {
 				r.Get("/oob", x.uiViewOutOfBoxSetup)
 				r.Get("/roster", x.uiViewRosterForm)
+				r.Get("/field", x.uiViewFieldForm)
 				r.Get("/net-wifi", x.uiViewNetWifi)
 				r.Get("/net-advanced", x.uiViewNetAdvanced)
 				r.Get("/integrations", x.uiViewIntegrations)

--- a/pkg/fms/ui/p2/base.p2
+++ b/pkg/fms/ui/p2/base.p2
@@ -22,4 +22,5 @@
   <script defer src="/static/js/toastify.js"></script>
   <script defer src="/static/js/reconnecting-websocket.js"></script>
   <script defer src="/static/js/gizmo.js"></script>
+  <script defer src="/static/js/mustache.js"></script>
 </html>

--- a/pkg/fms/ui/p2/fragments/nav.p2
+++ b/pkg/fms/ui/p2/fragments/nav.p2
@@ -10,6 +10,7 @@
         <div class="nav-dropdown">
           <a class="nav-item" href="/ui/admin/setup/oob">Out of Box</a>
           <a class="nav-item" href="/ui/admin/setup/roster">Roster</a>
+          <a class="nav-item" href="/ui/admin/setup/field">Fields</a>
           <a class="nav-item" href="/ui/admin/setup/integrations">Integrations</a>
           <a class="nav-item" href="/ui/admin/setup/net-wifi">WiFi Settings</a>
           <a class="nav-item" href="/ui/admin/setup/net-advanced">Advanced Network</a>

--- a/pkg/fms/ui/p2/views/setup/field.p2
+++ b/pkg/fms/ui/p2/views/setup/field.p2
@@ -1,0 +1,157 @@
+{% extends "../../base.p2" %}
+
+{% block title %}Field Setup | Gizmo FMS{% endblock %}
+
+{% block content %}
+<div class="flex-container flex-row flex-center">
+    <div class="flex-item flex-max foreground box">
+        <h1>Fields</h1>
+        <p>This page allows you to manage field hardware.</p>
+        <center><button id="btn-show-form" class="button">Add Field</button></center>
+        <div id="table">Loading Data...</div>
+    </div>
+</div>
+
+<div id="field_form" class="modal">
+    <div class="modal-box foreground box">
+        <div id="form">Form Goes Here</div>
+        <center>
+            <button id="btn-add-field" class="button">Save</button>
+            <button id="btn-cancel-form" class="button">Cancel</button>
+        </center>
+    </div>
+</div>
+
+{% verbatim %}
+<script id="table_template" type="x-tmpl-mustache">
+ <table>
+ <tr>
+ <th>Field</th>
+ <th>MAC</th>
+ <th>Channel</th>
+ <th>Delete</th>
+ </tr>
+ {{#fields}}
+ <tr>
+ <td>{{ ID }}</td>
+ <td>{{ MAC }}</td>
+ <td>{{ Channel }}</td>
+ <td><button id="btn-delete-field-{{ ID }}" class="button">X</button></td>
+ </tr>
+ {{/fields}}
+ </table>
+</script>
+
+<script id="form_template" type="x-tmpl-mustache">
+ <form id="field_form_root">
+ <table>
+ <tr>
+ <td><label for="field_number">Field Number</label></td>
+ <td><input type="number" id="field_number" name="field_number" value="{{ Number }}" /></td>
+ </tr>
+ <tr>
+ <td><label for="field_mac">MAC Address</label></td>
+ <td><input type="text" id="field_mac" name="field_mac" value="{{ MAC }}" /></td>
+ </tr>
+ <tr>
+ <td><label for="field_channel">Channel</label></td>
+ <td>
+ <select id="field_channel" name="field_channel">
+ <option value="AUTO">Auto</option>
+ <option value="1">1</option>
+ <option value="6">6</option>
+ <option value="11">11</option>
+ </select>
+ </td>
+ </tr>
+ </table>
+ </form>
+</script>
+{% endverbatim %}
+
+<script>
+ const tableTemplate = document.getElementById('table_template').innerHTML;
+ const table = document.getElementById('table');
+ const formTemplate = document.getElementById('form_template').innerHTML;
+ const form = document.getElementById('form');
+
+ const formModal = document.getElementById('field_form');
+ document.getElementById('btn-show-form').addEventListener('click', (event) => {
+     formModal.style.display = 'block';
+ });
+ document.getElementById('btn-cancel-form').addEventListener('click', (event) => {
+     formModal.style.display = 'none';
+     document.getElementById('field_form_root').reset();
+ });
+
+ async function renderTable() {
+     try {
+         const response = await fetch('/api/config');
+         if (!response.ok) {
+             throw new Error(`Response status: ${response.status}`);
+         }
+
+         const config = await response.json();
+         const fields = new Array();
+
+         for (const shadowId in config.Fields) {
+             fields.push(config.Fields[shadowId]);
+         }
+
+         const rendered = Mustache.render(tableTemplate, { fields: fields });
+         table.innerHTML = rendered;
+
+         for (const field of fields) {
+             document.getElementById('btn-delete-field-'+field.ID).addEventListener('click', (event) => {
+                 deleteField(field.ID);
+             });
+         }
+     } catch (error) {
+         console.error(error.message);
+     }
+ }
+
+ async function submitConfig() {
+     const fId = document.getElementById('field_number').value;
+     const fMAC = document.getElementById('field_mac').value;
+     const fChannel = document.getElementById('field_channel').value;
+
+     const fIP = '100.64.0.' + (9+parseInt(fId, 10));
+
+     const field = {
+         ID: parseInt(fId, 10),
+         MAC: fMAC,
+         IP: fIP,
+         Channel: fChannel,
+     }
+     console.log(field);
+
+     const response = await fetch("/api/setup/field/", {
+         method: "POST",
+         headers: {
+             "Content-Type": "application/json",
+         },
+         body: JSON.stringify(field),
+     });
+
+     formModal.style.display = 'none';
+     document.getElementById('field_form_root').reset();
+     renderTable();
+ }
+
+ async function deleteField(id) {
+     const response = await fetch("/api/setup/field/" + id, {
+         method: "DELETE",
+     });
+     renderTable();
+ }
+
+ document.getElementById('btn-add-field').addEventListener('click', submitConfig);
+
+ document.addEventListener('DOMContentLoaded', function() {
+     renderTable();
+     const rendered = Mustache.render(formTemplate, {});
+     form.innerHTML = rendered;
+ });
+</script>
+{% endblock %}

--- a/pkg/fms/ui/static/css/theme.css
+++ b/pkg/fms/ui/static/css/theme.css
@@ -215,6 +215,26 @@ code {
     background: black;
 }
 
+.modal {
+  display: none;
+  position: fixed;
+  z-index: 1;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  overflow: auto;
+  background-color: rgb(0,0,0);
+  background-color: rgba(0,0,0,0.4);
+}
+
+.modal-box {
+    width: 50%;
+    margin-left: auto;
+    margin-right: auto;
+    margin-top: 5%;
+}
+
 .nav-header {
     font-weight: 475;
     margin-left: 1em;


### PR DESCRIPTION
Adds both an API and page to manage fields.  Select API endpoints are available from the UI which is driven by more javascript than I'd like, but it keeps it consistent that almost everything else has become API based as the web UI is built out.

Part of #46 